### PR TITLE
generate html files in top level dir

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -1078,7 +1078,7 @@ GENERATE_HTML          = YES
 # The default directory is: html.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_OUTPUT            = html
+HTML_OUTPUT            = .
 
 # The HTML_FILE_EXTENSION tag can be used to specify the file extension for each
 # generated HTML page (for example: .htm, .php, .asp).


### PR DESCRIPTION
bad for most branches, good for gh-pages branch

If you ever want to look at the to-be documentation by running `doxygen Doxyfile` on a branch you're working on, change `HTML_OUTPUT` back to `html` so that it is in the ignored `html` directory. However, we want to output our HTML files to the top level dir so that github pages can find our index.html file without having to redirect.